### PR TITLE
Fixes the crash Nexus-Mods/Vortex/issues/9901

### DIFF
--- a/index.js
+++ b/index.js
@@ -102,11 +102,11 @@ function installAndRegisterArchives(files) {
 }
 
 // NOTE: `const mod` can be undefined when the profile still has data for a modId, but the mod might've been uninstalled
-function getBA2Mods(payload, condition) {
+function getBA2Mods(payload, excludeModCondition) {
   const { profile, state, gameId } = payload;
-  const BA2Mods = Object.keys(profile.modState).map(key => {
-    if (condition(profile, key)) return;
-    const mod = state.persistent.mods[gameId][key];
+  const BA2Mods = Object.keys(profile.modState).map(modId => {
+    if (!excludeModCondition(profile, modId)) return;
+    const mod = state.persistent.mods[gameId][modId];
     if (mod && mod.attributes && mod.attributes.ba2archives) return mod;
     else return;
   }).filter(m => m !== undefined);
@@ -121,11 +121,11 @@ function updateArchiveList(profile, api) {
 
   const payload = { profile, state, gameId }
 
-  // Join up all the BA2s into a single array.
-  const enabledBA2s = getBA2Mods(payload, (profile, key) => !profile.modState[key].enabled);
+  // Get all enabled BA2s into a single array.
+  const enabledBA2s = getBA2Mods(payload, (profile, modId) => profile.modState[modId].enabled);
 
-  // Join up all the disabled BA2s into a single array.
-  const disbledBA2s = getBA2Mods(payload, (profile, key) => profile.modState[key].enabled);
+  // Get all disabled BA2s into a single array.
+  const disbledBA2s = getBA2Mods(payload, (profile, modId) => !profile.modState[modId].enabled);
 
   const gamePath = state.settings.gameMode.discovered[GAME_ID].path;
   const dataFolder = path.join(gamePath, 'Data');

--- a/index.js
+++ b/index.js
@@ -101,30 +101,31 @@ function installAndRegisterArchives(files) {
   return Promise.resolve({ instructions });
 }
 
-function updateArchiveList(profile, api) {
-  const state = api.store.getState();
-  const gameId = profile.gameId;
-
-  // Filter through the enabled mods that have BA2 archives
-  const enabledBA2Mods = Object.keys(profile.modState).map(key => {
-    if (!profile.modState[key].enabled) return;
-    const mod = state.persistent.mods[gameId][key];
-    if (mod.attributes.ba2archives) return mod;
-    else return;
-  }).filter(m => m !== undefined);
-
-  // Join up all the BA2s into a single array.
-  const enabledBA2s = enabledBA2Mods.map((mod) => mod.attributes.ba2archives.join(',')).join(',').split(',');
-
-  const disabledBA2Mods = Object.keys(profile.modState).map(key => {
-    if (profile.modState[key].enabled) return;
+// NOTE: `const mod` can be undefined when the profile still has data for a modId, but the mod might've been uninstalled
+function getBA2Mods(payload, condition) {
+  const { profile, state, gameId } = payload;
+  const BA2Mods = Object.keys(profile.modState).map(key => {
+    if (condition(profile, key)) return;
     const mod = state.persistent.mods[gameId][key];
     if (mod && mod.attributes && mod.attributes.ba2archives) return mod;
     else return;
   }).filter(m => m !== undefined);
 
+  // Join up all the BA2s into a single array.
+  return BA2Mods.map((mod) => mod.attributes.ba2archives.join(',')).join(',').split(',');
+}
+
+function updateArchiveList(profile, api) {
+  const state = api.store.getState();
+  const gameId = profile.gameId;
+
+  const payload = { profile, state, gameId }
+
+  // Join up all the BA2s into a single array.
+  const enabledBA2s = getBA2Mods(payload, (profile, key) => !profile.modState[key].enabled);
+
   // Join up all the disabled BA2s into a single array.
-  const disbledBA2s = disabledBA2Mods.map((mod) => mod.attributes.ba2archives.join(',')).join(',').split(',');
+  const disbledBA2s = getBA2Mods(payload, (profile, key) => profile.modState[key].enabled);
 
   const gamePath = state.settings.gameMode.discovered[GAME_ID].path;
   const dataFolder = path.join(gamePath, 'Data');


### PR DESCRIPTION
This is a PR to fix the crash for https://github.com/Nexus-Mods/Vortex/issues/9901 and for https://github.com/Dakraid/Vortex_Fallout76/issues/6

In some rare instances, `state.persistent.mods[gameId][modId];` can be undefined when the profile still has data for a modId, but the mod might've been uninstalled

This fixes it and also removes the duplicated code to get the enabled and disabled mods.